### PR TITLE
fix deploy: remove redundant service update, pause on failure

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -85,11 +85,6 @@ jobs:
             export IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.workflow_run.head_sha }}
 
             cd ~/backlogbox
-            docker stack deploy --with-registry-auth -c docker-stack.yml backlogbox
-
-            docker service update \
-              --image $IMAGE \
-              --with-registry-auth \
-              backlogbox_app
+            docker stack deploy --with-registry-auth --detach=false -c docker-stack.yml backlogbox
 
             docker system prune -af --filter "until=72h"

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -61,7 +61,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
-      start_period: 30s
+      start_period: 45s
     deploy:
       replicas: 2
       placement:
@@ -70,10 +70,7 @@ services:
         parallelism: 1
         delay: 10s
         order: start-first
-        failure_action: rollback
-      rollback_config:
-        parallelism: 1
-        order: stop-first
+        failure_action: pause
       restart_policy:
         condition: on-failure
         delay: 5s


### PR DESCRIPTION
## Summary
- Remove redundant `docker service update` after `docker stack deploy` (caused death loop on first deploy)
- Add `--detach=false` to stack deploy for CI visibility
- Change `failure_action` from `rollback` to `pause` (rollback has nothing to roll back to on first deploy)
- Increase `start_period` 30s → 45s
- Remove `rollback_config` (re-add after first successful deploy)