### PR TITLE
fix healthcheck: use 127.0.0.1 instead of localhost

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -85,6 +85,6 @@ jobs:
             export IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.workflow_run.head_sha }}
 
             cd ~/backlogbox
-            docker stack deploy --with-registry-auth --detach=false -c docker-stack.yml backlogbox
+            docker stack deploy --with-registry-auth -c docker-stack.yml backlogbox
 
             docker system prune -af --filter "until=72h"

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -57,7 +57,7 @@ services:
     networks:
       - app_network
     healthcheck:
-      test: ['CMD', 'wget', '--spider', '-q', 'http://localhost:3000/healthz']
+      test: ['CMD', 'wget', '--spider', '-q', 'http://127.0.0.1:3000/healthz']
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- Fix healthcheck using `127.0.0.1` instead of `localhost` — Alpine's `wget` resolves `localhost` to IPv6 (`::1`), but Node listens on IPv4 only, causing connection refused
- Remove `--detach=false` from CD deploy step to prevent SSH action timeout