### PR TITLE
feat: UI polish — animations, transitions, wrapped overhaul

### DIFF
--- a/src/lib/components/board/BoardSearch.svelte
+++ b/src/lib/components/board/BoardSearch.svelte
@@ -2,8 +2,11 @@
 	import Search from '@lucide/svelte/icons/search';
 	import X from '@lucide/svelte/icons/x';
 	import { onMount } from 'svelte';
+	import { fade, scale } from 'svelte/transition';
+	import { prefersReducedMotion } from 'svelte/motion';
 
 	let { value = $bindable('') }: { value: string } = $props();
+	const noMotion = $derived(prefersReducedMotion.current);
 
 	let inputEl = $state<HTMLInputElement | null>(null);
 	let expanded = $state(false);
@@ -49,7 +52,11 @@
 
 <div class="relative flex items-center">
 	{#if expanded}
-		<div class="relative flex items-center">
+		<div
+			class="relative flex items-center"
+			in:scale={{ start: 0.95, duration: noMotion ? 0 : 150, opacity: 0 }}
+			out:fade={{ duration: noMotion ? 0 : 100 }}
+		>
 			<Search class="pointer-events-none absolute left-2.5 size-3.5 text-muted-foreground" />
 			<input
 				bind:this={inputEl}
@@ -79,6 +86,7 @@
 		<button
 			type="button"
 			onclick={open}
+			in:fade={{ duration: noMotion ? 0 : 150, delay: 50 }}
 			class="hidden items-center gap-1.5 rounded-md border border-input bg-background
 				px-2.5 py-1.5 text-muted-foreground shadow-xs transition
 				hover:bg-accent hover:text-foreground sm:flex"

--- a/src/lib/components/board/KanbanBoard.svelte
+++ b/src/lib/components/board/KanbanBoard.svelte
@@ -44,11 +44,11 @@
 
 	/** IDs of items that just appeared on the board — used for card-enter animation */
 	let recentlyAdded = new SvelteSet<string>();
-	let knownIds = new Set<string>();
+	let knownIds = new SvelteSet<string>();
 
 	/** Diff current items against known IDs to detect newly added items */
 	$effect(() => {
-		const currentIds = new Set<string>();
+		const currentIds = new SvelteSet<string>();
 		for (const status of MEDIA_STATUSES) {
 			for (const item of groupedItems[status]) currentIds.add(item.id);
 		}

--- a/src/lib/components/board/KanbanBoard.svelte
+++ b/src/lib/components/board/KanbanBoard.svelte
@@ -42,6 +42,34 @@
 	/** IDs of items that just moved to the "completed" column — used for glow animation */
 	let recentlyCompleted = new SvelteSet<string>();
 
+	/** IDs of items that just appeared on the board — used for card-enter animation */
+	let recentlyAdded = new SvelteSet<string>();
+	let knownIds = new Set<string>();
+
+	/** Diff current items against known IDs to detect newly added items */
+	$effect(() => {
+		const currentIds = new Set<string>();
+		for (const status of MEDIA_STATUSES) {
+			for (const item of groupedItems[status]) currentIds.add(item.id);
+		}
+
+		// Skip the initial render — don't animate items already on the board
+		if (knownIds.size > 0) {
+			const newIds: string[] = [];
+			for (const id of currentIds) {
+				if (!knownIds.has(id)) newIds.push(id);
+			}
+			if (newIds.length > 0) {
+				for (const id of newIds) recentlyAdded.add(id);
+				setTimeout(() => {
+					for (const id of newIds) recentlyAdded.delete(id);
+				}, 300);
+			}
+		}
+
+		knownIds = currentIds;
+	});
+
 	const STORAGE_PREFIX = 'bb:expanded:';
 	const DEFAULT_EXPANDED: MediaStatus[] = ['in_progress', 'backlog'];
 
@@ -142,6 +170,7 @@
 						color={STATUS_COLORS[status]}
 						items={columns[status] ?? []}
 						{recentlyCompleted}
+						{recentlyAdded}
 						{onCardClick}
 					/>
 				{/each}

--- a/src/lib/components/board/KanbanCard.svelte
+++ b/src/lib/components/board/KanbanCard.svelte
@@ -10,6 +10,7 @@
 		group?: string;
 		isOverlay?: boolean;
 		recentlyCompleted?: SvelteSet<string>;
+		recentlyAdded?: SvelteSet<string>;
 		onclick?: (item: MediaItemWithMeta) => void;
 	};
 
@@ -19,10 +20,12 @@
 		group = '',
 		isOverlay = false,
 		recentlyCompleted,
+		recentlyAdded,
 		onclick
 	}: Props = $props();
 
 	const glowing = $derived(recentlyCompleted?.has(item.id) ?? false);
+	const entering = $derived(recentlyAdded?.has(item.id) ?? false);
 
 	const sortable = useSortable({
 		id: () => item.id,
@@ -45,7 +48,8 @@
 		class="cursor-pointer rounded-lg border border-border bg-card p-2.5 transition select-none
 		{isDragging ? 'opacity-30' : 'opacity-100'}
 		{isOverlay ? 'shadow-lg ring-2 ring-ring' : 'hover:bg-accent'}
-		{glowing ? 'neon-glow' : ''}"
+		{glowing ? 'neon-glow' : ''}
+		{entering ? 'card-enter' : ''}"
 		onclick={() => onclick?.(item)}
 		onkeydown={(e) => {
 			if (e.key === 'Enter' || e.key === ' ') onclick?.(item);

--- a/src/lib/components/board/KanbanColumn.svelte
+++ b/src/lib/components/board/KanbanColumn.svelte
@@ -13,10 +13,12 @@
 		color: string;
 		items: MediaItemWithMeta[];
 		recentlyCompleted?: SvelteSet<string>;
+		recentlyAdded?: SvelteSet<string>;
 		onCardClick?: (item: MediaItemWithMeta) => void;
 	};
 
-	let { status, label, color, items, recentlyCompleted, onCardClick }: Props = $props();
+	let { status, label, color, items, recentlyCompleted, recentlyAdded, onCardClick }: Props =
+		$props();
 
 	const { ref, isDropTarget } = useDroppable({
 		id: () => status,
@@ -43,7 +45,14 @@
 	<ScrollArea class="min-h-0 flex-1" scrollbarYClasses="hidden">
 		<div class="flex flex-col gap-1.5 p-2" data-group={status}>
 			{#each items as item, index (item.id)}
-				<KanbanCard {item} {index} group={status} {recentlyCompleted} onclick={onCardClick} />
+				<KanbanCard
+					{item}
+					{index}
+					group={status}
+					{recentlyCompleted}
+					{recentlyAdded}
+					onclick={onCardClick}
+				/>
 			{/each}
 
 			{#if items.length === 0}

--- a/src/lib/components/custom-list/CustomKanbanBoard.svelte
+++ b/src/lib/components/custom-list/CustomKanbanBoard.svelte
@@ -43,6 +43,9 @@
 	/** Local mutable copy for optimistic DnD updates */
 	let columns = $derived(structuredClone(groupedItems));
 
+	/** IDs of items that just moved to the "completed" column — used for glow animation */
+	let recentlyCompleted = new SvelteSet<string>();
+
 	const STORAGE_PREFIX = 'bb:expanded:';
 	const DEFAULT_EXPANDED: CustomListStatus[] = ['doing', 'planned'];
 
@@ -85,6 +88,7 @@
 
 	async function handleDragEnd() {
 		const updates: Array<{ id: string; status: CustomListStatus; sortOrder: number }> = [];
+		const newlyCompleted: string[] = [];
 
 		for (const status of CUSTOM_LIST_STATUSES) {
 			const items = columns[status];
@@ -95,8 +99,18 @@
 				const sortOrder = i * 1000;
 				if (item.status !== status || item.sortOrder !== sortOrder) {
 					updates.push({ id: item.id, status, sortOrder });
+					if (status === 'completed' && item.status !== 'completed') {
+						newlyCompleted.push(item.id);
+					}
 				}
 			}
+		}
+
+		if (newlyCompleted.length > 0) {
+			for (const id of newlyCompleted) recentlyCompleted.add(id);
+			setTimeout(() => {
+				for (const id of newlyCompleted) recentlyCompleted.delete(id);
+			}, 800);
 		}
 
 		if (updates.length > 0) {
@@ -131,6 +145,7 @@
 						label={statusLabels[status]}
 						color={CUSTOM_LIST_STATUS_COLORS[status]}
 						items={columns[status] ?? []}
+						{recentlyCompleted}
 						{onCardClick}
 					/>
 				{/each}

--- a/src/lib/components/custom-list/CustomKanbanCard.svelte
+++ b/src/lib/components/custom-list/CustomKanbanCard.svelte
@@ -2,16 +2,27 @@
 	import { useSortable } from '@dnd-kit-svelte/svelte/sortable';
 	import CustomCardBody from './CustomCardBody.svelte';
 	import type { CustomListItemWithFields } from '$lib/server/db/custom-list-queries';
+	import type { SvelteSet } from 'svelte/reactivity';
 
 	type Props = {
 		item: CustomListItemWithFields;
 		index?: number;
 		group?: string;
 		isOverlay?: boolean;
+		recentlyCompleted?: SvelteSet<string>;
 		onclick?: (item: CustomListItemWithFields) => void;
 	};
 
-	let { item, index = 0, group = '', isOverlay = false, onclick }: Props = $props();
+	let {
+		item,
+		index = 0,
+		group = '',
+		isOverlay = false,
+		recentlyCompleted,
+		onclick
+	}: Props = $props();
+
+	const glowing = $derived(recentlyCompleted?.has(item.id) ?? false);
 
 	const sortable = useSortable({
 		id: () => item.id,
@@ -33,7 +44,8 @@
 		tabindex="0"
 		class="cursor-pointer rounded-lg border border-border bg-card p-2.5 transition select-none
 		{isDragging ? 'opacity-30' : 'opacity-100'}
-		{isOverlay ? 'shadow-lg ring-2 ring-ring' : 'hover:bg-accent'}"
+		{isOverlay ? 'shadow-lg ring-2 ring-ring' : 'hover:bg-accent'}
+		{glowing ? 'neon-glow' : ''}"
 		onclick={() => onclick?.(item)}
 		onkeydown={(e) => {
 			if (e.key === 'Enter' || e.key === ' ') onclick?.(item);
@@ -49,3 +61,22 @@
 		<CustomCardBody {item} />
 	</div>
 {/if}
+
+<style>
+	@keyframes neon-flash {
+		0% {
+			box-shadow:
+				0 0 8px #22c55e,
+				0 0 20px #22c55e60;
+			border-color: #22c55e;
+		}
+		100% {
+			box-shadow: none;
+			border-color: var(--color-border);
+		}
+	}
+
+	:global(.neon-glow) {
+		animation: neon-flash 0.8s ease-out;
+	}
+</style>

--- a/src/lib/components/custom-list/CustomKanbanColumn.svelte
+++ b/src/lib/components/custom-list/CustomKanbanColumn.svelte
@@ -5,16 +5,18 @@
 	import { ScrollArea } from '$lib/components/ui/scroll-area/index.js';
 	import type { CustomListStatus } from '$lib/types';
 	import type { CustomListItemWithFields } from '$lib/server/db/custom-list-queries';
+	import type { SvelteSet } from 'svelte/reactivity';
 
 	type Props = {
 		status: CustomListStatus;
 		label: string;
 		color: string;
 		items: CustomListItemWithFields[];
+		recentlyCompleted?: SvelteSet<string>;
 		onCardClick?: (item: CustomListItemWithFields) => void;
 	};
 
-	let { status, label, color, items, onCardClick }: Props = $props();
+	let { status, label, color, items, recentlyCompleted, onCardClick }: Props = $props();
 
 	const { ref, isDropTarget } = useDroppable({
 		id: () => status,
@@ -41,7 +43,7 @@
 	<ScrollArea class="min-h-0 flex-1" scrollbarYClasses="hidden">
 		<div class="flex flex-col gap-1.5 p-2" data-group={status}>
 			{#each items as item, index (item.id)}
-				<CustomKanbanCard {item} {index} group={status} onclick={onCardClick} />
+				<CustomKanbanCard {item} {index} group={status} {recentlyCompleted} onclick={onCardClick} />
 			{/each}
 
 			{#if items.length === 0}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -254,10 +254,10 @@
 			<div class="flex-1 space-y-0.5 overflow-y-auto p-2">
 				<a
 					href="/discover"
-					class="group flex items-center gap-2.5 rounded-lg px-3 py-1.5 text-sm font-medium transition
-					{discoverActive
-						? 'bg-sidebar-accent text-sidebar-accent-foreground'
-						: 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'}"
+					class="group flex items-center gap-2.5 rounded-lg border-l-2 px-3 py-1.5 text-sm font-medium transition
+				{discoverActive
+						? 'border-[#8B5CF6] bg-sidebar-accent text-sidebar-accent-foreground'
+						: 'border-transparent text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'}"
 					onclick={() => (sidebarOpen = false)}
 				>
 					<span class="shrink-0" style:color="#8B5CF6">
@@ -267,10 +267,10 @@
 				</a>
 				<a
 					href="/dashboard"
-					class="group flex items-center gap-2.5 rounded-lg px-3 py-1.5 text-sm font-medium transition
-					{dashboardActive
-						? 'bg-sidebar-accent text-sidebar-accent-foreground'
-						: 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'}"
+					class="group flex items-center gap-2.5 rounded-lg border-l-2 px-3 py-1.5 text-sm font-medium transition
+				{dashboardActive
+						? 'border-[#f59e0b] bg-sidebar-accent text-sidebar-accent-foreground'
+						: 'border-transparent text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'}"
 					onclick={() => (sidebarOpen = false)}
 				>
 					<span class="shrink-0" style:color="#f59e0b">
@@ -284,12 +284,13 @@
 					{@const itemCount = item.type ? data.itemCounts[item.type] : undefined}
 					<a
 						href={item.href}
-						class="group flex items-center gap-2.5 rounded-lg px-3 py-1.5 text-sm font-medium transition
-		{active
+						class="group flex items-center gap-2.5 rounded-lg border-l-2 px-3 py-1.5 text-sm font-medium transition
+	{active
 							? 'bg-sidebar-accent text-sidebar-accent-foreground'
-							: 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'}
-		{item.highlighted ? '' : 'opacity-50'}
-		{item.locked ? 'opacity-40' : ''}"
+							: 'border-transparent text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'}
+	{item.highlighted ? '' : 'opacity-50'}
+	{item.locked ? 'opacity-40' : ''}"
+						style:border-left-color={active ? item.color : undefined}
 						onclick={() => (sidebarOpen = false)}
 					>
 						<span
@@ -328,10 +329,10 @@
 						{@const Icon = getIconComponent(list.icon)}
 						<a
 							href="/lists/{list.slug}"
-							class="group flex items-center gap-2.5 rounded-lg px-3 py-1.5 text-sm font-medium transition
-							{listActive
-								? 'bg-sidebar-accent text-sidebar-accent-foreground'
-								: 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'}"
+							class="group flex items-center gap-2.5 rounded-lg border-l-2 px-3 py-1.5 text-sm font-medium transition
+						{listActive
+								? 'border-sidebar-primary bg-sidebar-accent text-sidebar-accent-foreground'
+								: 'border-transparent text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'}"
 							onclick={() => (sidebarOpen = false)}
 						>
 							<span class="shrink-0 text-muted-foreground">
@@ -461,10 +462,10 @@
 			<div class="space-y-0.5 p-2">
 				<a
 					href="/settings"
-					class="flex items-center gap-2.5 rounded-lg px-3 py-1.5 text-sm font-medium transition
-					{page.url.pathname === '/settings'
-						? 'bg-sidebar-accent text-sidebar-accent-foreground'
-						: 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'}"
+					class="flex items-center gap-2.5 rounded-lg border-l-2 px-3 py-1.5 text-sm font-medium transition
+				{page.url.pathname === '/settings'
+						? 'border-sidebar-primary bg-sidebar-accent text-sidebar-accent-foreground'
+						: 'border-transparent text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'}"
 					onclick={() => (sidebarOpen = false)}
 				>
 					<Settings

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -37,6 +37,8 @@
 	import Crown from '@lucide/svelte/icons/crown';
 	import Share2 from '@lucide/svelte/icons/share-2';
 	import MessageSquareMore from '@lucide/svelte/icons/message-square-more';
+	import { fade } from 'svelte/transition';
+	import { prefersReducedMotion } from 'svelte/motion';
 	import type { Component } from 'svelte';
 
 	let { children, data } = $props();
@@ -225,6 +227,7 @@
 		{#if sidebarOpen}
 			<div
 				class="fixed inset-0 z-30 bg-black/50 lg:hidden"
+				transition:fade={{ duration: prefersReducedMotion.current ? 0 : 150 }}
 				onclick={() => (sidebarOpen = false)}
 				onkeydown={() => {}}
 				role="presentation"

--- a/src/routes/(app)/discover/+page.svelte
+++ b/src/routes/(app)/discover/+page.svelte
@@ -46,6 +46,8 @@
 	import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
 	import SettingsIcon from '@lucide/svelte/icons/settings';
 	import type { Component } from 'svelte';
+	import { fade } from 'svelte/transition';
+	import { prefersReducedMotion } from 'svelte/motion';
 	import type { AccessLevel } from '$lib/server/access';
 	import UpgradeBanner from '$lib/components/UpgradeBanner.svelte';
 	import BookOpen from '@lucide/svelte/icons/book-open';
@@ -62,6 +64,7 @@
 		podcasts: Podcast
 	};
 
+	const noMotion = $derived(prefersReducedMotion.current);
 	const isFree = $derived((page.data.accessLevel as AccessLevel) === 'free');
 
 	let activeTab = $state<MediaTypeSlug>('movies');
@@ -286,42 +289,352 @@
 		{/each}
 	</div>
 
-	<!-- Recommendations -->
-	{#if type !== 'podcast'}
-		<section class="space-y-6">
-			<div class="flex items-center justify-between gap-2">
-				<div class="flex items-center gap-2">
-					<span style:color="#3B82F6"><Sparkles class="size-5" /></span>
-					<h2 class="text-lg font-semibold">For You</h2>
-				</div>
-				{#if !isFree}
-					<Button
-						variant="ghost"
-						size="sm"
-						class="h-7 gap-1.5 text-xs text-muted-foreground"
-						onclick={() => (manageExcludedOpen = true)}
-					>
-						<SettingsIcon class="size-3" />
-						Manage
-					</Button>
-				{/if}
-			</div>
+	{#key activeTab}
+		<div in:fade={{ duration: noMotion ? 0 : 200, delay: 50 }}>
+			<!-- Recommendations -->
+			{#if type !== 'podcast'}
+				<section class="space-y-6">
+					<div class="flex items-center justify-between gap-2">
+						<div class="flex items-center gap-2">
+							<span style:color="#3B82F6"><Sparkles class="size-5" /></span>
+							<h2 class="text-lg font-semibold">For You</h2>
+						</div>
+						{#if !isFree}
+							<Button
+								variant="ghost"
+								size="sm"
+								class="h-7 gap-1.5 text-xs text-muted-foreground"
+								onclick={() => (manageExcludedOpen = true)}
+							>
+								<SettingsIcon class="size-3" />
+								Manage
+							</Button>
+						{/if}
+					</div>
 
-			{#if isFree}
-				<UpgradeBanner
-					message="Personalized recommendations are a paid feature. Upgrade to get suggestions based on your library."
-					variant="overlay"
-				/>
-			{:else if recsQuery?.error}
-				<p class="py-8 text-center text-sm text-muted-foreground">
-					Could not load recommendations right now.
-				</p>
-			{:else if recsQuery?.loading}
-				{#each Array(2) as _, i (i)}
-					<div class="space-y-3">
-						<div class="h-4 w-48 animate-pulse rounded bg-muted"></div>
+					{#if isFree}
+						<UpgradeBanner
+							message="Personalized recommendations are a paid feature. Upgrade to get suggestions based on your library."
+							variant="overlay"
+						/>
+					{:else if recsQuery?.error}
+						<p class="py-8 text-center text-sm text-muted-foreground">
+							Could not load recommendations right now.
+						</p>
+					{:else if recsQuery?.loading}
+						{#each Array(2) as _, i (i)}
+							<div class="space-y-3">
+								<div class="h-4 w-48 animate-pulse rounded bg-muted"></div>
+								<div class="grid grid-cols-[repeat(auto-fill,minmax(6.5rem,1fr))] gap-3">
+									{#each Array(5) as _, j (j)}
+										<div class="animate-pulse space-y-1.5">
+											<div class="aspect-[2/3] rounded-md bg-muted"></div>
+											<div class="h-3 w-3/4 rounded bg-muted"></div>
+											<div class="h-3 w-1/2 rounded bg-muted"></div>
+										</div>
+									{/each}
+								</div>
+							</div>
+						{/each}
+					{:else if recsData.length === 0}
+						<div
+							class="flex h-40 items-center justify-center rounded-lg border border-dashed bg-muted/40 text-center text-sm text-muted-foreground"
+						>
+							Add some {type ? MEDIA_TYPE_LABELS[type].plural.toLowerCase() : 'items'} to your library
+							to get personalized recommendations.
+						</div>
+					{:else}
+						{#each recsData as group, i (i)}
+							<div
+								class="space-y-3 rounded-lg border border-border/50 bg-muted/20 p-4 {showDebug &&
+								group._debug
+									? debugBorderClass(group._debug)
+									: ''}"
+							>
+								<div class="flex items-center justify-between gap-2">
+									<h3 class="text-sm font-medium text-muted-foreground">
+										Because you added
+										<span
+											class="font-semibold text-foreground"
+											style:color={type ? MEDIA_TYPE_COLORS[type] : undefined}
+										>
+											{group.seedTitle}
+										</span>
+									</h3>
+									<div class="flex shrink-0 items-center gap-1.5">
+										{#if showDebug && group._debug}
+											<span
+												class="rounded border px-1.5 py-0.5 font-mono text-[10px] {debugBadgeClass(
+													group._debug
+												)}"
+											>
+												{debugLabel(group._debug)}
+											</span>
+										{/if}
+										<Tooltip.Root>
+											<Tooltip.Trigger>
+												<button
+													class="rounded-md p-1 text-muted-foreground/60 transition hover:bg-muted hover:text-muted-foreground"
+													onclick={() => (excludeConfirm = { group })}
+													aria-label="Don't recommend based on {group.seedTitle}"
+												>
+													<EyeOff class="size-3.5" />
+												</button>
+											</Tooltip.Trigger>
+											<Tooltip.Content>
+												<p>Don't recommend based on this</p>
+											</Tooltip.Content>
+										</Tooltip.Root>
+									</div>
+								</div>
+								<div class="grid grid-cols-[repeat(auto-fill,minmax(6.5rem,1fr))] gap-3">
+									{#each group.items as result (result.externalId)}
+										{@const isAdding = addingIds.has(result.externalId)}
+										<div class="group space-y-1.5">
+											<div class="relative aspect-[2/3] overflow-hidden rounded-md">
+												{#if result.coverUrl}
+													<img
+														src={result.coverUrl}
+														alt={result.title}
+														loading="lazy"
+														class="h-full w-full object-cover"
+													/>
+												{:else}
+													<div
+														class="flex h-full w-full items-center justify-center text-xl font-semibold text-white/80 select-none"
+														style:background-color="hsl({titleToHue(result.title)} 40% 30%)"
+													>
+														{result.title.trim().charAt(0).toUpperCase()}
+													</div>
+												{/if}
+												{#if result.description}
+													<Popover.Root>
+														<Popover.Trigger
+															class="absolute top-1 right-1 flex size-6 items-center justify-center rounded-full bg-black/50 text-white/80 transition-opacity hover:bg-black/70 sm:opacity-0 sm:group-hover:opacity-100"
+														>
+															<Info class="size-3" />
+														</Popover.Trigger>
+														<Popover.Content
+															class="max-h-64 w-64 overflow-y-auto text-xs"
+															side="bottom"
+															align="end"
+														>
+															<p>{result.description}</p>
+														</Popover.Content>
+													</Popover.Root>
+												{/if}
+												<div
+													class="absolute inset-x-0 bottom-0 flex bg-gradient-to-t from-black/60 to-transparent p-1.5 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
+												>
+													<div class="flex w-full gap-px">
+														<Button
+															variant="secondary"
+															size="sm"
+															class="h-7 flex-1 rounded-r-none text-xs"
+															disabled={isAdding}
+															onclick={() => handleAdd(result)}
+														>
+															{#if isAdding}
+																<LoaderCircle class="size-3 animate-spin" />
+															{:else}
+																<Plus class="size-3" />
+															{/if}
+															Add
+														</Button>
+														<DropdownMenu.Root>
+															<DropdownMenu.Trigger
+																class="flex h-7 items-center rounded-r-md bg-secondary px-1 text-secondary-foreground transition-colors hover:bg-secondary/80 disabled:pointer-events-none disabled:opacity-50"
+																disabled={isAdding}
+															>
+																<ChevronDown class="size-3" />
+															</DropdownMenu.Trigger>
+															<DropdownMenu.Portal>
+																<DropdownMenu.Content align="end" class="min-w-[8rem]">
+																	{#each MEDIA_STATUSES as s (s)}
+																		<DropdownMenu.Item onclick={() => handleAdd(result, s)}>
+																			{type ? STATUS_LABELS[type][s] : s}
+																		</DropdownMenu.Item>
+																	{/each}
+																</DropdownMenu.Content>
+															</DropdownMenu.Portal>
+														</DropdownMenu.Root>
+													</div>
+												</div>
+											</div>
+											<p class="truncate text-xs font-medium">{result.title}</p>
+											<p class="truncate text-[11px] text-muted-foreground">
+												{subtitle(result)}
+											</p>
+										</div>
+									{/each}
+								</div>
+							</div>
+						{/each}
+					{/if}
+				</section>
+				<Separator />
+			{/if}
+
+			<!-- Anticipated / Upcoming -->
+			{#if anticipatedQuery}
+				<section class="space-y-3">
+					<div class="flex items-center justify-between gap-2">
+						<div class="flex items-center gap-2">
+							<span style:color="#F97316"><Rocket class="size-5" /></span>
+							<h2 class="text-lg font-semibold">{anticipatedLabel}</h2>
+						</div>
+						{#if showDebug && anticipatedDebug}
+							<span
+								class="shrink-0 rounded border px-1.5 py-0.5 font-mono text-[10px] {debugBadgeClass(
+									anticipatedDebug
+								)}"
+							>
+								{debugLabel(anticipatedDebug)}
+							</span>
+						{/if}
+					</div>
+
+					<div
+						class="rounded-lg border border-border/50 bg-muted/20 p-4 {showDebug && anticipatedDebug
+							? debugBorderClass(anticipatedDebug)
+							: ''}"
+					>
+						{#if anticipatedQuery.error}
+							<p class="py-8 text-center text-sm text-muted-foreground">
+								Could not load {anticipatedLabel.toLowerCase()} items right now.
+							</p>
+						{:else if anticipatedQuery.loading}
+							<div class="grid grid-cols-[repeat(auto-fill,minmax(6.5rem,1fr))] gap-3">
+								{#each Array(10) as _, i (i)}
+									<div class="animate-pulse space-y-1.5">
+										<div class="aspect-[2/3] rounded-md bg-muted"></div>
+										<div class="h-3 w-3/4 rounded bg-muted"></div>
+										<div class="h-3 w-1/2 rounded bg-muted"></div>
+									</div>
+								{/each}
+							</div>
+						{:else if anticipatedData.length === 0}
+							<p class="py-8 text-center text-sm text-muted-foreground">
+								No {anticipatedLabel.toLowerCase()} items available right now.
+							</p>
+						{:else}
+							<div class="grid grid-cols-[repeat(auto-fill,minmax(6.5rem,1fr))] gap-3">
+								{#each anticipatedData.slice(0, 20) as result (result.externalId)}
+									{@const isAdding = addingIds.has(result.externalId)}
+									<div class="group space-y-1.5">
+										<div class="relative aspect-[2/3] overflow-hidden rounded-md">
+											{#if result.coverUrl}
+												<img
+													src={result.coverUrl}
+													alt={result.title}
+													loading="lazy"
+													class="h-full w-full object-cover"
+												/>
+											{:else}
+												<div
+													class="flex h-full w-full items-center justify-center text-xl font-semibold text-white/80 select-none"
+													style:background-color="hsl({titleToHue(result.title)} 40% 30%)"
+												>
+													{result.title.trim().charAt(0).toUpperCase()}
+												</div>
+											{/if}
+											{#if result.description}
+												<Popover.Root>
+													<Popover.Trigger
+														class="absolute top-1 right-1 flex size-6 items-center justify-center rounded-full bg-black/50 text-white/80 transition-opacity hover:bg-black/70 sm:opacity-0 sm:group-hover:opacity-100"
+													>
+														<Info class="size-3" />
+													</Popover.Trigger>
+													<Popover.Content
+														class="max-h-64 w-64 overflow-y-auto text-xs"
+														side="bottom"
+														align="end"
+													>
+														<p>{result.description}</p>
+													</Popover.Content>
+												</Popover.Root>
+											{/if}
+											<div
+												class="absolute inset-x-0 bottom-0 flex bg-gradient-to-t from-black/60 to-transparent p-1.5 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
+											>
+												<div class="flex w-full gap-px">
+													<Button
+														variant="secondary"
+														size="sm"
+														class="h-7 flex-1 rounded-r-none text-xs"
+														disabled={isAdding}
+														onclick={() => handleAdd(result)}
+													>
+														{#if isAdding}
+															<LoaderCircle class="size-3 animate-spin" />
+														{:else}
+															<Plus class="size-3" />
+														{/if}
+														Add
+													</Button>
+													<DropdownMenu.Root>
+														<DropdownMenu.Trigger
+															class="flex h-7 items-center rounded-r-md bg-secondary px-1 text-secondary-foreground transition-colors hover:bg-secondary/80 disabled:pointer-events-none disabled:opacity-50"
+															disabled={isAdding}
+														>
+															<ChevronDown class="size-3" />
+														</DropdownMenu.Trigger>
+														<DropdownMenu.Portal>
+															<DropdownMenu.Content align="end" class="min-w-[8rem]">
+																{#each MEDIA_STATUSES as s (s)}
+																	<DropdownMenu.Item onclick={() => handleAdd(result, s)}>
+																		{type ? STATUS_LABELS[type][s] : s}
+																	</DropdownMenu.Item>
+																{/each}
+															</DropdownMenu.Content>
+														</DropdownMenu.Portal>
+													</DropdownMenu.Root>
+												</div>
+											</div>
+										</div>
+										<p class="truncate text-xs font-medium">{result.title}</p>
+										<p class="truncate text-[11px] text-muted-foreground">
+											{subtitle(result, { showFullDate: true })}
+										</p>
+									</div>
+								{/each}
+							</div>
+						{/if}
+					</div>
+				</section>
+				<Separator />
+			{/if}
+
+			<!-- Trending -->
+			<section class="space-y-3">
+				<div class="flex items-center justify-between gap-2">
+					<div class="flex items-center gap-2">
+						<span style:color="#A855F7"><TrendingUp class="size-5" /></span>
+						<h2 class="text-lg font-semibold">Trending</h2>
+					</div>
+					{#if showDebug && trendingDebug}
+						<span
+							class="shrink-0 rounded border px-1.5 py-0.5 font-mono text-[10px] {debugBadgeClass(
+								trendingDebug
+							)}"
+						>
+							{debugLabel(trendingDebug)}
+						</span>
+					{/if}
+				</div>
+
+				<div
+					class="rounded-lg border border-border/50 bg-muted/20 p-4 {showDebug && trendingDebug
+						? debugBorderClass(trendingDebug)
+						: ''}"
+				>
+					{#if trendingQuery.error}
+						<p class="py-8 text-center text-sm text-muted-foreground">
+							Could not load trending items right now.
+						</p>
+					{:else if trendingQuery.loading}
 						<div class="grid grid-cols-[repeat(auto-fill,minmax(6.5rem,1fr))] gap-3">
-							{#each Array(5) as _, j (j)}
+							{#each Array(10) as _, i (i)}
 								<div class="animate-pulse space-y-1.5">
 									<div class="aspect-[2/3] rounded-md bg-muted"></div>
 									<div class="h-3 w-3/4 rounded bg-muted"></div>
@@ -329,61 +642,13 @@
 								</div>
 							{/each}
 						</div>
-					</div>
-				{/each}
-			{:else if recsData.length === 0}
-				<div
-					class="flex h-40 items-center justify-center rounded-lg border border-dashed bg-muted/40 text-center text-sm text-muted-foreground"
-				>
-					Add some {type ? MEDIA_TYPE_LABELS[type].plural.toLowerCase() : 'items'} to your library to
-					get personalized recommendations.
-				</div>
-			{:else}
-				{#each recsData as group, i (i)}
-					<div
-						class="space-y-3 rounded-lg border border-border/50 bg-muted/20 p-4 {showDebug &&
-						group._debug
-							? debugBorderClass(group._debug)
-							: ''}"
-					>
-						<div class="flex items-center justify-between gap-2">
-							<h3 class="text-sm font-medium text-muted-foreground">
-								Because you added
-								<span
-									class="font-semibold text-foreground"
-									style:color={type ? MEDIA_TYPE_COLORS[type] : undefined}
-								>
-									{group.seedTitle}
-								</span>
-							</h3>
-							<div class="flex shrink-0 items-center gap-1.5">
-								{#if showDebug && group._debug}
-									<span
-										class="rounded border px-1.5 py-0.5 font-mono text-[10px] {debugBadgeClass(
-											group._debug
-										)}"
-									>
-										{debugLabel(group._debug)}
-									</span>
-								{/if}
-								<Tooltip.Root>
-									<Tooltip.Trigger>
-										<button
-											class="rounded-md p-1 text-muted-foreground/60 transition hover:bg-muted hover:text-muted-foreground"
-											onclick={() => (excludeConfirm = { group })}
-											aria-label="Don't recommend based on {group.seedTitle}"
-										>
-											<EyeOff class="size-3.5" />
-										</button>
-									</Tooltip.Trigger>
-									<Tooltip.Content>
-										<p>Don't recommend based on this</p>
-									</Tooltip.Content>
-								</Tooltip.Root>
-							</div>
-						</div>
+					{:else if trendingData.length === 0}
+						<p class="py-8 text-center text-sm text-muted-foreground">
+							No trending items available right now.
+						</p>
+					{:else}
 						<div class="grid grid-cols-[repeat(auto-fill,minmax(6.5rem,1fr))] gap-3">
-							{#each group.items as result (result.externalId)}
+							{#each trendingData.slice(0, 20) as result (result.externalId)}
 								{@const isAdding = addingIds.has(result.externalId)}
 								<div class="group space-y-1.5">
 									<div class="relative aspect-[2/3] overflow-hidden rounded-md">
@@ -457,273 +722,15 @@
 										</div>
 									</div>
 									<p class="truncate text-xs font-medium">{result.title}</p>
-									<p class="truncate text-[11px] text-muted-foreground">
-										{subtitle(result)}
-									</p>
+									<p class="truncate text-[11px] text-muted-foreground">{subtitle(result)}</p>
 								</div>
 							{/each}
 						</div>
-					</div>
-				{/each}
-			{/if}
-		</section>
-		<Separator />
-	{/if}
-
-	<!-- Anticipated / Upcoming -->
-	{#if anticipatedQuery}
-		<section class="space-y-3">
-			<div class="flex items-center justify-between gap-2">
-				<div class="flex items-center gap-2">
-					<span style:color="#F97316"><Rocket class="size-5" /></span>
-					<h2 class="text-lg font-semibold">{anticipatedLabel}</h2>
+					{/if}
 				</div>
-				{#if showDebug && anticipatedDebug}
-					<span
-						class="shrink-0 rounded border px-1.5 py-0.5 font-mono text-[10px] {debugBadgeClass(
-							anticipatedDebug
-						)}"
-					>
-						{debugLabel(anticipatedDebug)}
-					</span>
-				{/if}
-			</div>
-
-			<div
-				class="rounded-lg border border-border/50 bg-muted/20 p-4 {showDebug && anticipatedDebug
-					? debugBorderClass(anticipatedDebug)
-					: ''}"
-			>
-				{#if anticipatedQuery.error}
-					<p class="py-8 text-center text-sm text-muted-foreground">
-						Could not load {anticipatedLabel.toLowerCase()} items right now.
-					</p>
-				{:else if anticipatedQuery.loading}
-					<div class="grid grid-cols-[repeat(auto-fill,minmax(6.5rem,1fr))] gap-3">
-						{#each Array(10) as _, i (i)}
-							<div class="animate-pulse space-y-1.5">
-								<div class="aspect-[2/3] rounded-md bg-muted"></div>
-								<div class="h-3 w-3/4 rounded bg-muted"></div>
-								<div class="h-3 w-1/2 rounded bg-muted"></div>
-							</div>
-						{/each}
-					</div>
-				{:else if anticipatedData.length === 0}
-					<p class="py-8 text-center text-sm text-muted-foreground">
-						No {anticipatedLabel.toLowerCase()} items available right now.
-					</p>
-				{:else}
-					<div class="grid grid-cols-[repeat(auto-fill,minmax(6.5rem,1fr))] gap-3">
-						{#each anticipatedData.slice(0, 20) as result (result.externalId)}
-							{@const isAdding = addingIds.has(result.externalId)}
-							<div class="group space-y-1.5">
-								<div class="relative aspect-[2/3] overflow-hidden rounded-md">
-									{#if result.coverUrl}
-										<img
-											src={result.coverUrl}
-											alt={result.title}
-											loading="lazy"
-											class="h-full w-full object-cover"
-										/>
-									{:else}
-										<div
-											class="flex h-full w-full items-center justify-center text-xl font-semibold text-white/80 select-none"
-											style:background-color="hsl({titleToHue(result.title)} 40% 30%)"
-										>
-											{result.title.trim().charAt(0).toUpperCase()}
-										</div>
-									{/if}
-									{#if result.description}
-										<Popover.Root>
-											<Popover.Trigger
-												class="absolute top-1 right-1 flex size-6 items-center justify-center rounded-full bg-black/50 text-white/80 transition-opacity hover:bg-black/70 sm:opacity-0 sm:group-hover:opacity-100"
-											>
-												<Info class="size-3" />
-											</Popover.Trigger>
-											<Popover.Content
-												class="max-h-64 w-64 overflow-y-auto text-xs"
-												side="bottom"
-												align="end"
-											>
-												<p>{result.description}</p>
-											</Popover.Content>
-										</Popover.Root>
-									{/if}
-									<div
-										class="absolute inset-x-0 bottom-0 flex bg-gradient-to-t from-black/60 to-transparent p-1.5 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
-									>
-										<div class="flex w-full gap-px">
-											<Button
-												variant="secondary"
-												size="sm"
-												class="h-7 flex-1 rounded-r-none text-xs"
-												disabled={isAdding}
-												onclick={() => handleAdd(result)}
-											>
-												{#if isAdding}
-													<LoaderCircle class="size-3 animate-spin" />
-												{:else}
-													<Plus class="size-3" />
-												{/if}
-												Add
-											</Button>
-											<DropdownMenu.Root>
-												<DropdownMenu.Trigger
-													class="flex h-7 items-center rounded-r-md bg-secondary px-1 text-secondary-foreground transition-colors hover:bg-secondary/80 disabled:pointer-events-none disabled:opacity-50"
-													disabled={isAdding}
-												>
-													<ChevronDown class="size-3" />
-												</DropdownMenu.Trigger>
-												<DropdownMenu.Portal>
-													<DropdownMenu.Content align="end" class="min-w-[8rem]">
-														{#each MEDIA_STATUSES as s (s)}
-															<DropdownMenu.Item onclick={() => handleAdd(result, s)}>
-																{type ? STATUS_LABELS[type][s] : s}
-															</DropdownMenu.Item>
-														{/each}
-													</DropdownMenu.Content>
-												</DropdownMenu.Portal>
-											</DropdownMenu.Root>
-										</div>
-									</div>
-								</div>
-								<p class="truncate text-xs font-medium">{result.title}</p>
-								<p class="truncate text-[11px] text-muted-foreground">
-									{subtitle(result, { showFullDate: true })}
-								</p>
-							</div>
-						{/each}
-					</div>
-				{/if}
-			</div>
-		</section>
-		<Separator />
-	{/if}
-
-	<!-- Trending -->
-	<section class="space-y-3">
-		<div class="flex items-center justify-between gap-2">
-			<div class="flex items-center gap-2">
-				<span style:color="#A855F7"><TrendingUp class="size-5" /></span>
-				<h2 class="text-lg font-semibold">Trending</h2>
-			</div>
-			{#if showDebug && trendingDebug}
-				<span
-					class="shrink-0 rounded border px-1.5 py-0.5 font-mono text-[10px] {debugBadgeClass(
-						trendingDebug
-					)}"
-				>
-					{debugLabel(trendingDebug)}
-				</span>
-			{/if}
+			</section>
 		</div>
-
-		<div
-			class="rounded-lg border border-border/50 bg-muted/20 p-4 {showDebug && trendingDebug
-				? debugBorderClass(trendingDebug)
-				: ''}"
-		>
-			{#if trendingQuery.error}
-				<p class="py-8 text-center text-sm text-muted-foreground">
-					Could not load trending items right now.
-				</p>
-			{:else if trendingQuery.loading}
-				<div class="grid grid-cols-[repeat(auto-fill,minmax(6.5rem,1fr))] gap-3">
-					{#each Array(10) as _, i (i)}
-						<div class="animate-pulse space-y-1.5">
-							<div class="aspect-[2/3] rounded-md bg-muted"></div>
-							<div class="h-3 w-3/4 rounded bg-muted"></div>
-							<div class="h-3 w-1/2 rounded bg-muted"></div>
-						</div>
-					{/each}
-				</div>
-			{:else if trendingData.length === 0}
-				<p class="py-8 text-center text-sm text-muted-foreground">
-					No trending items available right now.
-				</p>
-			{:else}
-				<div class="grid grid-cols-[repeat(auto-fill,minmax(6.5rem,1fr))] gap-3">
-					{#each trendingData.slice(0, 20) as result (result.externalId)}
-						{@const isAdding = addingIds.has(result.externalId)}
-						<div class="group space-y-1.5">
-							<div class="relative aspect-[2/3] overflow-hidden rounded-md">
-								{#if result.coverUrl}
-									<img
-										src={result.coverUrl}
-										alt={result.title}
-										loading="lazy"
-										class="h-full w-full object-cover"
-									/>
-								{:else}
-									<div
-										class="flex h-full w-full items-center justify-center text-xl font-semibold text-white/80 select-none"
-										style:background-color="hsl({titleToHue(result.title)} 40% 30%)"
-									>
-										{result.title.trim().charAt(0).toUpperCase()}
-									</div>
-								{/if}
-								{#if result.description}
-									<Popover.Root>
-										<Popover.Trigger
-											class="absolute top-1 right-1 flex size-6 items-center justify-center rounded-full bg-black/50 text-white/80 transition-opacity hover:bg-black/70 sm:opacity-0 sm:group-hover:opacity-100"
-										>
-											<Info class="size-3" />
-										</Popover.Trigger>
-										<Popover.Content
-											class="max-h-64 w-64 overflow-y-auto text-xs"
-											side="bottom"
-											align="end"
-										>
-											<p>{result.description}</p>
-										</Popover.Content>
-									</Popover.Root>
-								{/if}
-								<div
-									class="absolute inset-x-0 bottom-0 flex bg-gradient-to-t from-black/60 to-transparent p-1.5 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
-								>
-									<div class="flex w-full gap-px">
-										<Button
-											variant="secondary"
-											size="sm"
-											class="h-7 flex-1 rounded-r-none text-xs"
-											disabled={isAdding}
-											onclick={() => handleAdd(result)}
-										>
-											{#if isAdding}
-												<LoaderCircle class="size-3 animate-spin" />
-											{:else}
-												<Plus class="size-3" />
-											{/if}
-											Add
-										</Button>
-										<DropdownMenu.Root>
-											<DropdownMenu.Trigger
-												class="flex h-7 items-center rounded-r-md bg-secondary px-1 text-secondary-foreground transition-colors hover:bg-secondary/80 disabled:pointer-events-none disabled:opacity-50"
-												disabled={isAdding}
-											>
-												<ChevronDown class="size-3" />
-											</DropdownMenu.Trigger>
-											<DropdownMenu.Portal>
-												<DropdownMenu.Content align="end" class="min-w-[8rem]">
-													{#each MEDIA_STATUSES as s (s)}
-														<DropdownMenu.Item onclick={() => handleAdd(result, s)}>
-															{type ? STATUS_LABELS[type][s] : s}
-														</DropdownMenu.Item>
-													{/each}
-												</DropdownMenu.Content>
-											</DropdownMenu.Portal>
-										</DropdownMenu.Root>
-									</div>
-								</div>
-							</div>
-							<p class="truncate text-xs font-medium">{result.title}</p>
-							<p class="truncate text-[11px] text-muted-foreground">{subtitle(result)}</p>
-						</div>
-					{/each}
-				</div>
-			{/if}
-		</div>
-	</section>
+	{/key}
 </div>
 
 <!-- Exclude confirmation dialog -->

--- a/src/routes/(app)/onboarding/+page.svelte
+++ b/src/routes/(app)/onboarding/+page.svelte
@@ -22,6 +22,9 @@
 	import ArrowRight from '@lucide/svelte/icons/arrow-right';
 	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+	import { fly, fade } from 'svelte/transition';
+	import { prefersReducedMotion } from 'svelte/motion';
+	import { cubicOut } from 'svelte/easing';
 	import type { Component } from 'svelte';
 	import { SvelteSet } from 'svelte/reactivity';
 
@@ -60,6 +63,8 @@
 	let submitting = $state(false);
 
 	const selectedCount = $derived(selectedItems.size);
+
+	const noMotion = $derived(prefersReducedMotion.current);
 
 	trackEvent('onboarding_started');
 
@@ -202,7 +207,11 @@
 	<!-- ===================================================================== -->
 	<!-- STEP 1: Interest Selection                                            -->
 	<!-- ===================================================================== -->
-	<div class="flex min-h-screen flex-col items-center justify-center">
+	<div
+		class="flex min-h-screen flex-col items-center justify-center"
+		in:fly={{ x: noMotion ? 0 : -40, duration: noMotion ? 0 : 300, easing: cubicOut }}
+		out:fade={{ duration: noMotion ? 0 : 150 }}
+	>
 		<div class="flex flex-col items-center">
 			<!-- Logo -->
 			<div class="onboarding-fade flex items-center gap-2.5" style="animation-delay: 0ms">
@@ -307,7 +316,11 @@
 	<!-- ===================================================================== -->
 	<!-- STEP 2: Seed Your Backlog                                             -->
 	<!-- ===================================================================== -->
-	<div class="flex min-h-screen w-full flex-col justify-center py-6">
+	<div
+		class="flex min-h-screen w-full flex-col justify-center py-6"
+		in:fly={{ x: noMotion ? 0 : 40, duration: noMotion ? 0 : 300, easing: cubicOut }}
+		out:fade={{ duration: noMotion ? 0 : 150 }}
+	>
 		<div class="onboarding-fade text-center" style="animation-delay: 0ms">
 			<h1 class="onboarding-gradient text-2xl font-bold tracking-tight sm:text-3xl">
 				Add some items to get started

--- a/src/routes/(app)/wrapped/[year]/+page.svelte
+++ b/src/routes/(app)/wrapped/[year]/+page.svelte
@@ -3,6 +3,7 @@
 	import { MEDIA_TYPES, MEDIA_TYPE_LABELS, MEDIA_TYPE_COLORS, type MediaType } from '$lib/types';
 	import { Tween, prefersReducedMotion } from 'svelte/motion';
 	import { cubicOut } from 'svelte/easing';
+	import { SvelteSet } from 'svelte/reactivity';
 	import MediaCover from '$lib/components/board/MediaCover.svelte';
 	import BookOpen from '@lucide/svelte/icons/book-open';
 	import Film from '@lucide/svelte/icons/film';
@@ -105,12 +106,11 @@
 	// ---------------------------------------------------------------------------
 
 	/** Tracks which card indices have been revealed */
-	let revealed = $state<Set<number>>(new Set());
+	const revealed = new SvelteSet<number>();
 
 	function observeReveal(node: HTMLElement, index: number) {
 		if (!browser || noMotion) {
 			revealed.add(index);
-			revealed = new Set(revealed);
 			return;
 		}
 
@@ -119,7 +119,6 @@
 				for (const entry of entries) {
 					if (entry.isIntersecting) {
 						revealed.add(index);
-						revealed = new Set(revealed);
 						observer.disconnect();
 					}
 				}

--- a/src/routes/(app)/wrapped/[year]/+page.svelte
+++ b/src/routes/(app)/wrapped/[year]/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import { MEDIA_TYPES, MEDIA_TYPE_LABELS, MEDIA_TYPE_COLORS, type MediaType } from '$lib/types';
+	import { Tween, prefersReducedMotion } from 'svelte/motion';
+	import { cubicOut } from 'svelte/easing';
 	import MediaCover from '$lib/components/board/MediaCover.svelte';
 	import BookOpen from '@lucide/svelte/icons/book-open';
 	import Film from '@lucide/svelte/icons/film';
@@ -17,6 +20,7 @@
 
 	let { data }: { data: PageData } = $props();
 	const s = $derived(data.stats);
+	const noMotion = $derived(prefersReducedMotion.current);
 
 	const TYPE_ICONS: Record<MediaType, Component<{ class?: string }>> = {
 		book: BookOpen,
@@ -74,37 +78,109 @@
 	);
 
 	const maxTypeCount = $derived(Math.max(...MEDIA_TYPES.map((t) => s.completedByType[t]), 1));
+
+	// ---------------------------------------------------------------------------
+	// Animated counters (tweened from 0 to target)
+	// ---------------------------------------------------------------------------
+
+	// Capture motion preference at mount — Tween duration is set once, not reactive
+	const tweenDuration = prefersReducedMotion.current ? 0 : 800;
+	const heroCounter = new Tween(0, { duration: tweenDuration, easing: cubicOut });
+	const hoursCounter = new Tween(0, { duration: tweenDuration, easing: cubicOut });
+	const ratingCounter = new Tween(0, { duration: tweenDuration, easing: cubicOut });
+
+	// Drive Tween targets from scroll-reveal state (card indices: 0=hero, 2=hours, 7=rating)
+	$effect(() => {
+		if (revealed.has(0)) heroCounter.set(s.totalCompleted);
+	});
+	$effect(() => {
+		if (revealed.has(2)) hoursCounter.set(s.totalEstimatedHours);
+	});
+	$effect(() => {
+		if (revealed.has(7) && s.averageRating !== null) ratingCounter.set(s.averageRating);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Scroll-triggered reveal via IntersectionObserver
+	// ---------------------------------------------------------------------------
+
+	/** Tracks which card indices have been revealed */
+	let revealed = $state<Set<number>>(new Set());
+
+	function observeReveal(node: HTMLElement, index: number) {
+		if (!browser || noMotion) {
+			revealed.add(index);
+			revealed = new Set(revealed);
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) {
+						revealed.add(index);
+						revealed = new Set(revealed);
+						observer.disconnect();
+					}
+				}
+			},
+			{ threshold: 0.15 }
+		);
+
+		observer.observe(node);
+
+		return {
+			destroy() {
+				observer.disconnect();
+			}
+		};
+	}
+
+	function cardStyle(index: number): string {
+		if (noMotion || revealed.has(index)) return '';
+		return `opacity: 0; transform: translateY(12px);`;
+	}
 </script>
 
 <svelte:head>
 	<title>Your {s.year} Wrapped | BacklogBox</title>
 </svelte:head>
 
-<div class="min-h-screen bg-gradient-to-br from-[#0f0f23] via-[#1a1a3e] to-[#0f0f23]">
-	<div class="mx-auto max-w-lg space-y-6 px-4 py-12 lg:py-16">
+<div class="min-h-screen bg-background">
+	<div class="mx-auto max-w-lg space-y-5 px-4 py-12 lg:py-16">
 		<!-- Hero -->
-		<div class="text-center">
-			<p class="mb-2 text-sm font-bold tracking-[0.3em] uppercase" style:color="#8B5CF6">
+		<div class="wrapped-card text-center" use:observeReveal={0} style={cardStyle(0)}>
+			<p class="mb-2 text-sm font-bold tracking-[0.3em] text-muted-foreground uppercase">
 				Your {s.year} Wrapped
 			</p>
 			<h1
 				class="bg-gradient-to-r from-purple-400 via-pink-400 to-amber-400 bg-clip-text text-6xl font-black tracking-tight text-transparent sm:text-7xl"
 			>
-				{s.totalCompleted}
+				{Math.round(heroCounter.current)}
 			</h1>
-			<p class="mt-2 text-lg text-white/60">
+			<p class="mt-2 text-lg text-muted-foreground">
 				{s.totalCompleted === 1 ? 'item' : 'items'} completed
 			</p>
 		</div>
 
 		{#if s.totalCompleted === 0}
-			<div class="rounded-2xl border border-white/10 bg-white/5 p-8 text-center backdrop-blur-sm">
-				<p class="text-lg text-white/50">No completed items this year yet. Keep going!</p>
+			<div
+				class="wrapped-card rounded-2xl border border-border bg-card p-8 text-center"
+				use:observeReveal={1}
+				style={cardStyle(1)}
+			>
+				<p class="text-lg text-muted-foreground">No completed items this year yet. Keep going!</p>
 			</div>
 		{:else}
 			<!-- Type breakdown -->
-			<div class="space-y-4 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm">
-				<h2 class="text-sm font-bold tracking-wider text-white/40 uppercase">Your year in media</h2>
+			<div
+				class="wrapped-card space-y-4 rounded-2xl border border-border bg-card p-6"
+				use:observeReveal={1}
+				style={cardStyle(1)}
+			>
+				<h2 class="text-sm font-bold tracking-wider text-muted-foreground/60 uppercase">
+					Your year in media
+				</h2>
 				<div class="space-y-3">
 					{#each activeTypes as t (t)}
 						{@const Icon = TYPE_ICONS[t]}
@@ -115,7 +191,7 @@
 									<span style:color={MEDIA_TYPE_COLORS[t]}>
 										<Icon class="size-4" />
 									</span>
-									<span class="text-sm font-medium text-white/80">
+									<span class="text-sm font-medium text-foreground/80">
 										{MEDIA_TYPE_LABELS[t].plural}
 									</span>
 								</div>
@@ -123,10 +199,10 @@
 									{s.completedByType[t]}
 								</span>
 							</div>
-							<div class="h-2 overflow-hidden rounded-full bg-white/5">
+							<div class="h-2 overflow-hidden rounded-full bg-muted">
 								<div
 									class="h-full rounded-full transition-all duration-1000 ease-out"
-									style:width="{pct}%"
+									style:width={revealed.has(1) ? `${pct}%` : '0%'}
 									style:background={MEDIA_TYPE_COLORS[t]}
 								></div>
 							</div>
@@ -138,25 +214,37 @@
 			<!-- Estimated hours -->
 			{#if s.totalEstimatedHours > 0}
 				<div
-					class="rounded-2xl border border-white/10 bg-gradient-to-br from-purple-900/30 to-indigo-900/30 p-6 text-center backdrop-blur-sm"
+					class="wrapped-card rounded-2xl border border-border bg-card p-6 text-center"
+					use:observeReveal={2}
+					style={cardStyle(2)}
 				>
-					<ClockIcon class="mx-auto mb-2 size-8 text-purple-400" />
-					<p class="text-4xl font-black text-white tabular-nums">
-						~{s.totalEstimatedHours}
+					<div
+						class="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-purple-500/10"
+					>
+						<ClockIcon class="size-6 text-purple-400" />
+					</div>
+					<p class="text-4xl font-black text-foreground tabular-nums">
+						~{Math.round(hoursCounter.current)}
 					</p>
-					<p class="mt-1 text-sm text-white/50">estimated hours spent</p>
+					<p class="mt-1 text-sm text-muted-foreground">estimated hours spent</p>
 				</div>
 			{/if}
 
 			<!-- Top genre -->
 			{#if s.topGenre}
 				<div
-					class="rounded-2xl border border-white/10 bg-gradient-to-br from-emerald-900/30 to-teal-900/30 p-6 text-center backdrop-blur-sm"
+					class="wrapped-card rounded-2xl border border-border bg-card p-6 text-center"
+					use:observeReveal={3}
+					style={cardStyle(3)}
 				>
-					<FlameIcon class="mx-auto mb-2 size-8 text-emerald-400" />
-					<p class="text-sm text-white/50">Top genre</p>
-					<p class="mt-1 text-3xl font-black text-white">{s.topGenre.genre}</p>
-					<p class="mt-1 text-sm text-white/40">
+					<div
+						class="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-emerald-500/10"
+					>
+						<FlameIcon class="size-6 text-emerald-400" />
+					</div>
+					<p class="text-sm text-muted-foreground">Top genre</p>
+					<p class="mt-1 text-3xl font-black text-foreground">{s.topGenre.genre}</p>
+					<p class="mt-1 text-sm text-muted-foreground/60">
 						{s.topGenre.count}
 						{s.topGenre.count === 1 ? 'item' : 'items'}
 					</p>
@@ -165,7 +253,11 @@
 
 			<!-- Highest rated -->
 			{#if s.highestRated}
-				<div class="overflow-hidden rounded-2xl border border-white/10 bg-white/5 backdrop-blur-sm">
+				<div
+					class="wrapped-card overflow-hidden rounded-2xl border border-border bg-card"
+					use:observeReveal={4}
+					style={cardStyle(4)}
+				>
 					<div class="flex items-center gap-4 p-6">
 						<div class="size-20 shrink-0 overflow-hidden rounded-xl">
 							<MediaCover title={s.highestRated.title} coverUrl={s.highestRated.coverUrl} />
@@ -175,13 +267,13 @@
 								<Trophy class="size-4" />
 								<span class="text-xs font-bold tracking-wider uppercase"> Highest rated </span>
 							</div>
-							<p class="mt-1 text-lg font-bold text-white">{s.highestRated.title}</p>
+							<p class="mt-1 text-lg font-bold text-foreground">{s.highestRated.title}</p>
 							<div class="mt-1 flex items-center gap-1">
 								{#each Array(5) as _, i (i)}
 									<Star
 										class="size-4 {i < s.highestRated.rating
 											? 'fill-amber-400 text-amber-400'
-											: 'text-white/20'}"
+											: 'text-muted-foreground/20'}"
 									/>
 								{/each}
 							</div>
@@ -193,7 +285,9 @@
 			<!-- Fastest completion -->
 			{#if s.fastestCompletion}
 				<div
-					class="overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-orange-900/30 to-red-900/30 backdrop-blur-sm"
+					class="wrapped-card overflow-hidden rounded-2xl border border-border bg-card"
+					use:observeReveal={5}
+					style={cardStyle(5)}
 				>
 					<div class="flex items-center gap-4 p-6">
 						<div class="size-20 shrink-0 overflow-hidden rounded-xl">
@@ -207,10 +301,10 @@
 								<Zap class="size-4" />
 								<span class="text-xs font-bold tracking-wider uppercase"> Speed run </span>
 							</div>
-							<p class="mt-1 text-lg font-bold text-white">
+							<p class="mt-1 text-lg font-bold text-foreground">
 								{s.fastestCompletion.title}
 							</p>
-							<p class="mt-0.5 text-sm text-white/50">
+							<p class="mt-0.5 text-sm text-muted-foreground">
 								Finished in {s.fastestCompletion.days === 0
 									? 'less than a day'
 									: `${s.fastestCompletion.days} day${s.fastestCompletion.days === 1 ? '' : 's'}`}
@@ -223,14 +317,20 @@
 			<!-- Most active month -->
 			{#if s.mostActiveMonth}
 				<div
-					class="rounded-2xl border border-white/10 bg-gradient-to-br from-blue-900/30 to-cyan-900/30 p-6 text-center backdrop-blur-sm"
+					class="wrapped-card rounded-2xl border border-border bg-card p-6 text-center"
+					use:observeReveal={6}
+					style={cardStyle(6)}
 				>
-					<CalendarIcon class="mx-auto mb-2 size-8 text-blue-400" />
-					<p class="text-sm text-white/50">Most active month</p>
-					<p class="mt-1 text-3xl font-black text-white">
+					<div
+						class="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-blue-500/10"
+					>
+						<CalendarIcon class="size-6 text-blue-400" />
+					</div>
+					<p class="text-sm text-muted-foreground">Most active month</p>
+					<p class="mt-1 text-3xl font-black text-foreground">
 						{formatMonth(s.mostActiveMonth.month)}
 					</p>
-					<p class="mt-1 text-sm text-white/40">
+					<p class="mt-1 text-sm text-muted-foreground/60">
 						{s.mostActiveMonth.count} completed
 					</p>
 				</div>
@@ -238,31 +338,41 @@
 
 			<!-- Average rating -->
 			{#if s.averageRating !== null}
-				<div class="rounded-2xl border border-white/10 bg-white/5 p-6 text-center backdrop-blur-sm">
+				<div
+					class="wrapped-card rounded-2xl border border-border bg-card p-6 text-center"
+					use:observeReveal={7}
+					style={cardStyle(7)}
+				>
 					<Star class="mx-auto mb-2 size-8 fill-amber-400 text-amber-400" />
-					<p class="text-sm text-white/50">Average rating</p>
-					<p class="mt-1 text-4xl font-black text-white tabular-nums">
-						{s.averageRating}
+					<p class="text-sm text-muted-foreground">Average rating</p>
+					<p class="mt-1 text-4xl font-black text-foreground tabular-nums">
+						{ratingCounter.current.toFixed(1)}
 					</p>
-					<p class="mt-1 text-sm text-white/40">out of 5</p>
+					<p class="mt-1 text-sm text-muted-foreground/60">out of 5</p>
 				</div>
 			{/if}
 
 			<!-- First & last -->
 			{#if s.firstCompleted && s.lastCompleted && s.totalCompleted > 1}
-				<div class="space-y-4 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm">
-					<h2 class="text-sm font-bold tracking-wider text-white/40 uppercase">Bookends</h2>
+				<div
+					class="wrapped-card space-y-4 rounded-2xl border border-border bg-card p-6"
+					use:observeReveal={8}
+					style={cardStyle(8)}
+				>
+					<h2 class="text-sm font-bold tracking-wider text-muted-foreground/60 uppercase">
+						Bookends
+					</h2>
 					<div class="space-y-3">
 						<div class="flex items-center gap-3">
 							<div class="size-12 shrink-0 overflow-hidden rounded-lg">
 								<MediaCover title={s.firstCompleted.title} coverUrl={s.firstCompleted.coverUrl} />
 							</div>
 							<div class="min-w-0 flex-1">
-								<p class="text-xs text-white/40">First completed</p>
-								<p class="truncate font-medium text-white">
+								<p class="text-xs text-muted-foreground/60">First completed</p>
+								<p class="truncate font-medium text-foreground">
 									{s.firstCompleted.title}
 								</p>
-								<p class="text-xs text-white/40">
+								<p class="text-xs text-muted-foreground/60">
 									{formatDate(s.firstCompleted.date)}
 								</p>
 							</div>
@@ -272,11 +382,11 @@
 								<MediaCover title={s.lastCompleted.title} coverUrl={s.lastCompleted.coverUrl} />
 							</div>
 							<div class="min-w-0 flex-1">
-								<p class="text-xs text-white/40">Last completed</p>
-								<p class="truncate font-medium text-white">
+								<p class="text-xs text-muted-foreground/60">Last completed</p>
+								<p class="truncate font-medium text-foreground">
 									{s.lastCompleted.title}
 								</p>
-								<p class="text-xs text-white/40">
+								<p class="text-xs text-muted-foreground/60">
 									{formatDate(s.lastCompleted.date)}
 								</p>
 							</div>
@@ -289,10 +399,9 @@
 			{#if topType}
 				{@const Icon = TYPE_ICONS[topType]}
 				<div
-					class="rounded-2xl border border-white/10 p-8 text-center backdrop-blur-sm"
-					style:background="linear-gradient(135deg, {MEDIA_TYPE_COLORS[topType]}15, {MEDIA_TYPE_COLORS[
-						topType
-					]}05)"
+					class="wrapped-card rounded-2xl border border-border bg-card p-8 text-center"
+					use:observeReveal={9}
+					style={cardStyle(9)}
 				>
 					<div
 						class="mx-auto mb-3 flex size-16 items-center justify-center rounded-full"
@@ -301,10 +410,10 @@
 					>
 						<Icon class="size-8" />
 					</div>
-					<p class="text-sm text-white/50">
+					<p class="text-sm text-muted-foreground">
 						You were a {MEDIA_TYPE_LABELS[topType].singular.toLowerCase()} person this year
 					</p>
-					<p class="mt-1 text-2xl font-black text-white">
+					<p class="mt-1 text-2xl font-black text-foreground">
 						{s.completedByType[topType]}
 						{MEDIA_TYPE_LABELS[topType].plural.toLowerCase()} completed
 					</p>
@@ -314,9 +423,22 @@
 
 		<!-- Footer -->
 		<div class="pt-6 text-center">
-			<a href="/dashboard" class="text-sm text-white/30 transition hover:text-white/60">
+			<a
+				href="/dashboard"
+				class="text-sm text-muted-foreground/50 transition hover:text-muted-foreground"
+			>
 				Back to dashboard
 			</a>
 		</div>
 	</div>
 </div>
+
+<style>
+	@media (prefers-reduced-motion: no-preference) {
+		.wrapped-card {
+			transition:
+				opacity 250ms ease-out,
+				transform 250ms ease-out;
+		}
+	}
+</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import './layout.css';
 	import { dev } from '$app/environment';
 	import { page } from '$app/state';
+	import { onNavigate } from '$app/navigation';
 	import { env } from '$env/dynamic/public';
 	import { onMount } from 'svelte';
 	import { ModeWatcher } from 'mode-watcher';
@@ -16,6 +17,17 @@
 
 	// --- Analytics (pageviews auto-tracked via defaults: '2026-01-30') ---
 	initPostHog(env.PUBLIC_POSTHOG_KEY, env.PUBLIC_POSTHOG_HOST);
+
+	// --- View Transitions API — subtle crossfade between pages ---
+	onNavigate((navigation) => {
+		if (!document.startViewTransition) return;
+		return new Promise((resolve) => {
+			document.startViewTransition(async () => {
+				resolve();
+				await navigation.complete;
+			});
+		});
+	});
 
 	// --- PWA service worker registration ---
 	onMount(async () => {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -126,7 +126,7 @@
 
 <ModeWatcher defaultMode="dark" />
 <Toaster richColors />
-<Tooltip.Provider>
+<Tooltip.Provider delayDuration={300} skipDelayDuration={150}>
 	<IosInstallHint />
 	{#if dev}
 		<CacheDebugOverlay />

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -170,6 +170,22 @@
 }
 
 /* ------------------------------------------------------------------ */
+/* Card enter animation — new items fade+slide in                      */
+/* ------------------------------------------------------------------ */
+@media (prefers-reduced-motion: no-preference) {
+	@keyframes card-enter {
+		from {
+			opacity: 0;
+			transform: translateY(6px) scale(0.98);
+		}
+	}
+
+	.card-enter {
+		animation: card-enter 180ms ease-out;
+	}
+}
+
+/* ------------------------------------------------------------------ */
 /* Collapsible height animation (mobile kanban sections)               */
 /* ------------------------------------------------------------------ */
 @media (prefers-reduced-motion: no-preference) {

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -137,6 +137,78 @@
 }
 
 /* ------------------------------------------------------------------ */
+/* View Transitions — subtle crossfade between page navigations        */
+/* ------------------------------------------------------------------ */
+@media (prefers-reduced-motion: no-preference) {
+	::view-transition-old(root),
+	::view-transition-new(root) {
+		animation-duration: 150ms;
+		animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+	}
+
+	::view-transition-old(root) {
+		animation-name: vt-fade-out;
+	}
+
+	::view-transition-new(root) {
+		animation-name: vt-fade-in;
+	}
+
+	@keyframes vt-fade-out {
+		to {
+			opacity: 0;
+			filter: blur(2px);
+		}
+	}
+
+	@keyframes vt-fade-in {
+		from {
+			opacity: 0;
+			filter: blur(2px);
+		}
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* Collapsible height animation (mobile kanban sections)               */
+/* ------------------------------------------------------------------ */
+@media (prefers-reduced-motion: no-preference) {
+	[data-slot='collapsible-content'][data-state='open'] {
+		animation: collapsible-open 200ms ease-out;
+	}
+
+	[data-slot='collapsible-content'][data-state='closed'] {
+		animation: collapsible-close 150ms ease-out forwards;
+	}
+
+	@keyframes collapsible-open {
+		from {
+			height: 0;
+			opacity: 0;
+			overflow: hidden;
+		}
+		to {
+			height: var(--bits-collapsible-content-height);
+			opacity: 1;
+			overflow: hidden;
+		}
+	}
+
+	@keyframes collapsible-close {
+		from {
+			height: var(--bits-collapsible-content-height);
+			opacity: 1;
+			overflow: hidden;
+		}
+		to {
+			height: 0;
+			opacity: 0;
+			overflow: hidden;
+		}
+	}
+}
+
+/* ------------------------------------------------------------------ */
 /* Reduced motion: kill all animation/transition for a11y              */
 /* ------------------------------------------------------------------ */
 @media (prefers-reduced-motion: reduce) {

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -136,6 +136,32 @@
 	}
 }
 
+/* ------------------------------------------------------------------ */
+/* Reduced motion: kill all animation/transition for a11y              */
+/* ------------------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		scroll-behavior: auto !important;
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* Tactile button press — subtle scale on :active (Emil Kowalski #1)  */
+/* ------------------------------------------------------------------ */
+@media (prefers-reduced-motion: no-preference) {
+	button:active:not(:disabled),
+	[role='button']:active:not(:disabled),
+	a[data-slot='button']:active {
+		transform: scale(0.97);
+		transition: transform 100ms ease-out;
+	}
+}
+
 @layer base {
 	* {
 		@apply border-border outline-ring/50;


### PR DESCRIPTION
## Summary

Comprehensive animation and interaction quality pass across the app, inspired by Emil Kowalski's animation tips. Zero new dependencies — CSS + Svelte built-in transitions only.

- **Reduced motion**: Global `prefers-reduced-motion` CSS kills all animations; Svelte transitions respect `prefersReducedMotion`
- **Tactile buttons**: `:active` scale(0.97) on all buttons
- **Page transitions**: View Transitions API via `onNavigate` (150ms fade+blur crossfade)
- **Sidebar**: Mobile backdrop fade transition; 2px colored left-border indicator on active nav links
- **Discover tabs**: `{#key}` + `in:fade` crossfade on tab content switch
- **Onboarding**: `in:fly` left/right between steps with `out:fade`
- **Board search**: `in:scale` + `out:fade` on search bar toggle
- **Collapsible sections**: CSS height animation via bits-ui `data-state` attrs + `--bits-collapsible-content-height`
- **Card enter**: CSS class-based `card-enter` animation (fade+slide+scale) on newly added items via ID diffing in `$effect`
- **Custom list glow**: Ported `recentlyCompleted` SvelteSet + `neon-flash` keyframe from media boards
- **Tooltip**: `delayDuration={300} skipDelayDuration={150}` for snappy subsequent hovers
- **Wrapped page overhaul**: Re-themed from hardcoded dark to design system tokens (works in light+dark mode); IntersectionObserver scroll-triggered reveal with staggered opacity/translateY; `Tween` class counters for hero number, hours, rating; animated progress bars

## Test Plan

### Reduced motion
- [ ] Enable `prefers-reduced-motion: reduce` in OS/browser — verify all animations disabled
- [ ] Disable it — verify animations play

### Buttons
- [ ] Click and hold any button — verify subtle scale-down on press

### Page transitions
- [ ] Navigate between pages — verify brief fade+blur crossfade (browsers supporting View Transitions API)
- [ ] In Safari/Firefox (no VT API) — verify no errors, graceful fallback

### Sidebar
- [ ] Mobile: open sidebar — verify backdrop fades in, closes on tap
- [ ] Verify active nav link has colored 2px left border matching its icon color
- [ ] Navigate between pages — verify indicator updates immediately

### Discover
- [ ] Switch between tabs (Trending/Recommended/Search) — verify content fades in

### Onboarding
- [ ] Step through onboarding — verify steps fly in from direction of progress
- [ ] Go back — verify reverse direction

### Board search
- [ ] Open search on a board — verify scale+fade in
- [ ] Close search — verify fade out

### Collapsible sections
- [ ] Mobile: tap a kanban column header — verify smooth height animation open/close

### Card enter
- [ ] Add an item to a board — verify new card animates in (fade+slide+scale)
- [ ] Page load — verify existing cards do NOT animate (only new additions)

### Custom list glow
- [ ] Move an item to "Done" column — verify brief green glow on the card

### Tooltips
- [ ] Hover a tooltip trigger — verify ~300ms delay
- [ ] Move to adjacent tooltip trigger quickly — verify near-instant show (skip delay)

### Wrapped page
- [ ] Navigate to /wrapped/2025 (or current year) — verify:
  - Cards reveal on scroll with stagger
  - Hero number counts up from 0
  - Progress bars animate width from 0%
  - Hours and rating counters tween
  - Works in both light and dark mode
  - No hardcoded dark background colors
- [ ] Enable reduced motion — verify all reveals instant, no animation

### Regression
- [ ] Drag and drop cards between columns — verify still works (no `animate:flip` conflicts)
- [ ] All 48 e2e tests pass
- [ ] `npm run lint` clean
- [ ] `svelte-check` 0 errors